### PR TITLE
Create FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [AmeelioDev]
+custom: ["https://letters.ameelio.org/donate", ameelio.org]


### PR DESCRIPTION
Enable sponsorship button on repo as described [here](https://help.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository). I think the github section will work with our AmeelioDev org account though further setup may be required. I don't have access to the org settings though.