### PR TITLE
Remove broken sponsor link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
-github: [AmeelioDev]
 custom: ["https://letters.ameelio.org/donate", ameelio.org]


### PR DESCRIPTION
We should remove the `github` line from the funding.yml file until GitHub approves our Org for sponsorships.